### PR TITLE
Removed side action buttons by css instead of javascript

### DIFF
--- a/myscript.js
+++ b/myscript.js
@@ -15,14 +15,14 @@ function updateButtons(){
 		return;
 	}
 	var i = 0;
-	//iterate through the buttons 
+	//iterate through the buttons
 	for(i=0; i < buttons.length; i++){
 		//replace compose button with new
 		if(buttons[i].textContent === "COMPOSE"){
 			//replace the text of compose button with 'new'
 			buttons[i].textContent = "NEW";
 			console.log('compose button replaced');
-		//remove checkbox button	
+		//remove checkbox button
 		}else if(buttons[i].querySelector("span[role=checkbox]") != null){
 			buttons[i].remove();
 			console.log('checkbox button removed');
@@ -42,26 +42,13 @@ function updateButtons(){
 	}
 }
 
-// Removes actions checkboxes; starring, selecting, important
-function removeSideActions() {
-  $(".k0vOLb").hide(); // first three table columns
-  $(".Ci").hide();
-  $(".y5").hide();
-  $(".oZ-x3.xY").hide(); // checkbox
-  $("td.oZ-x3.xY.aid").hide(); //checkbox
-  $("td.apU.xY").hide(); //star
-  $("td.WA.xY").hide(); //important
-  console.log("remove side actions ran");
-}
 
 function emailLoaded(){
 	updateButtons();
-  removeSideActions();
 }
 
 function emailListLoaded(){
 	updateButtons();
-  removeSideActions();
 }
 
 $( document ).ready( function() {
@@ -74,22 +61,22 @@ $( document ).ready( function() {
 			emailListLoaded();
 			observer2.observe(targetNode, observerConfig);
 		}
-		    
+
 	});
 
 	// Notify only when nodes are added/deleted
 	var observerConfig = {
-		childList: true, 
+		childList: true,
 		subtree: true
 	};
-	
+
 	//start observing the body of the document for addition of nodes
 	var targetNode = document.body;
 	observer1.observe(targetNode, observerConfig);
-	
+
 	//create an observer to detect switch between email list and email
 	observer2 =  new MutationObserver(function(){
-		
+
 		if(document.body.querySelector("div[role=main] table[role=presentation]") == null){
 			if(listPage!=true){
 				listPage = true;
@@ -100,9 +87,6 @@ $( document ).ready( function() {
 			emailLoaded();
 		}
 	})
-		
-	
+
+
 	});
-
-
-

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,22 @@ td.yX { /*spacing out the table rows*/
   padding-bottom: 20px !important;
 }
 
+div.pH.a9q {
+	display: none;
+}
+
+span.aXw.T-KT {
+	display: none;
+}
+
+div.oZ-jc.T-Jo.J-J5-Ji {
+	display: none;
+}
+
+div.pH-A7.a9q {
+	display: none;
+}
+
 body {
   font-size: 20px;
 }

--- a/styles.css
+++ b/styles.css
@@ -9,18 +9,22 @@ td.yX { /*spacing out the table rows*/
 }
 
 div.pH.a9q {
+	/* Important buttons on the left side of the email list */
 	display: none;
 }
 
 span.aXw.T-KT {
+	/* Star buttons on the left side of the email list */
 	display: none;
 }
 
 div.oZ-jc.T-Jo.J-J5-Ji {
+	/* Checkbox buttons on the left side of the email list */
 	display: none;
 }
 
 div.pH-A7.a9q {
+	/* Unimportant buttons on the left side of the email list */
 	display: none;
 }
 


### PR DESCRIPTION
When we were using JavaScript, an incoming email will mess up the page because the "star", "select" and "important" buttons on the new email will not be automatically removed.
Now these changes are made with CSS, thus the changes are automatically made even when a new email is received or page is refreshed.